### PR TITLE
improve setup files

### DIFF
--- a/ceph_cluster.yml
+++ b/ceph_cluster.yml
@@ -8,7 +8,7 @@ parameters:
  netmask: 255.255.255.0
  numcpus: 1
  memory: 6144
- image: fedora38
+ image: fedora43
  notify: false
  admin_password: password
  disks:
@@ -23,6 +23,9 @@ parameters:
  reserveip: true
  reservedns: true
  sharedkey: true
+ user: fedora
+ keys:
+  - ~/.ssh/id_ed25519.pub
  nets:
   - name: {{ network_1 }}
     ip: {{ ip_prefix_1 }}.{{ node_ip_offset + number }}
@@ -37,7 +40,7 @@ parameters:
  files:
   - bootstrap-cluster.sh
  cmds:
- - dnf -y install python3 chrony lvm2 podman nano strace firewalld tcpdump
+ - dnf -y install python3 chrony lvm2 podman nano strace firewalld tcpdump net-tools
  - sed -i "s/SELINUX=enforcing/SELINUX=permissive/" /etc/selinux/config
  - setenforce 0
  {% if number == 0 %}


### PR DESCRIPTION
The motivation for these changes comes from many trials and errors encountered in the process of getting this to work. This PR does the following changes to the setup scripts: 

In `bootstrap-cluster.sh`:

1. `set -x` for easier debugging. Adding this helped solve a lot of issues which was difficult when the script was failing without logging how far it got. 
2. Changing cephadm binary permissions from `+x` to `a+rx`. 
3. Network interface naming was updated to the latest convention `ens3` from the old `eth0`. 
4. When the cephadm binary is created on a debian distro, the shebang added is specific to the python version (eg - `#!/usr/bin/python3.10`) instead of the generic `#!/usr/bin/python3` given by fedora/RH based ones. Changing the invocation of `cephadm` with `python3 /root/bin/cephadm` will ensure it works for cephadm binaries generated on any of the above distros. 


In `ceph_cluster.yml`

1. Update fedora version to the latest as the old ones aren't available on KCLI by default and finding the qcow2 type image for feodra38 (expected format by KCLI) was difficult.  
2. `user: fedora` is required as the specified keys land in `fedora` user which is needed to login to other nodes from the root node. 
3. Install net-tools. When this is absent, `ifconfig` was complaining. 
