### PR TITLE
Issue/supporting proxy for developers who must be using http proxy

### DIFF
--- a/ceph_cluster.yml
+++ b/ceph_cluster.yml
@@ -1,7 +1,7 @@
 parameters:
  nodes: 3
  node_ip_offset: 100
- pool: ceph-orch
+ pool: default
  node_prefix_1: ceph
  network_1: ceph-orch
  ip_prefix_1: 192.168.100
@@ -11,20 +11,17 @@ parameters:
  image: fedora43
  notify: false
  admin_password: password
- # --- CHANGE START ---
  container_cfg:
    engine:
-     env:   #when you are behind vpn or similar env and require to pass through a proxy ,put your proxy configyuration
+     env:   # when you are behind vpn or similar env and require to pass through a proxy ,put your proxy configyuration
        #- HTTP_PROXY: "http://example.net:8080"
        #- HTTPS_PROXY: "http://example.net:8080"
        #- http_proxy: "http://example.net:8080"
        #- https_proxy: "http://example.net:8080"
        - NO_PROXY: "localhost,127.0.0.1,{{ ip_prefix_1 }}.0/24"
- # We now define disks as objects to allow setting the 'serial'
  disks:
  - size: 100               # Disk 1 (OS)
  - size: 10                # Disk 2 (Ceph Data)
- # --- CHANGE END ---
 
 {% for number in range(0, nodes) %}
 {{ node_prefix_1 }}-node-{{ '%d' % number }}:


### PR DESCRIPTION
There are some developers who will work with VPN that will block the VM's from directly going towards
an external source like quay.ceph.io/ceph-ci/ceph:main  to pull images and will force using http proxy server.
for those we suggest adding an option to configure HA proxy 

the suggested code review allows putting the http proxy values to be set in the container infrastructure file /etc/containers/containers.conf , to update it with the values while deploying.
without this the deployment will fail to pull the ceph image and will not start , only the vm's will be running.

we have another maybe more general approach to include configuration files during the cloudinit
that will be supplied by the user before running the kcli create plan command but we will share it in a different review

regards 
