### PR TITLE
Document IPv6 options added to the ceph_cluster.yml in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,20 @@ sudo nano /etc/ssh/sshd_config (and set PermitRootLogin to yes)
 sudo systemctl restart sshd
 ```
 
+IPv6 network configuration:
+
+To add IPv6 addresses to the cluster nodes, alongside IPv4, on the same network interface configured by **network_interface_name**, set the following parameters:
+
+NOTE: The IPv6 prefix length should be /64
+1. **ipv6_prefix_1**: Set your IPv6 prefix (e.g., `2620:52:0:1304`). 
+2. **node_ip_offset** : Set your IPv6 offset (e.g., `100`)
+3. **network_interface_type**: Set to `ipv6`
+
+The network interface configuration will be automatically applied during cluster setup using `nmcli` to configure the network connection dynamically based on the specified interface name. For the above example the following subnet
+will be created on the network interface configured by **network_interface_name**:
+- 2620:52:0:1304::/64
+Hosts added to the ceph cluster in bootstrap-cluster.sh will be given an IPv6 address with an incrementing offset.
+
 To create a 3-node Ceph cluster:
 
 ``` bash
@@ -38,10 +52,15 @@ Or for development:
 kcli create plan -f ./ceph_cluster.yml -P ceph_dev_folder=<path-to-your-ceph-src> -P expanded_cluster=true ceph
 ```
 
-This will create a new 3-node Ceph cluster with the following nodes:
+For IPv4 this will create a new 3-node Ceph cluster with the following nodes:
 - ceph-node-0 (192.168.100.100)
 - ceph-node-1 (192.168.100.101)
 - ceph-node-2 (192.168.100.102)
+
+For IPv6 this will create a new 3-node Ceph cluster with the following nodes:
+- ceph-node-0 (2620:52:0:1304::64)
+- ceph-node-1 (2620:52:0:1304::65)
+- ceph-node-2 (2620:52:0:1304::66)
 
 The user can open a shell on any node with a command of the following form, where X is the number of the node):
 


### PR DESCRIPTION
These changes to the ceph_cluster.yml enable creating an additional IPv6 network on the existing network interface used for IPv4. The README.md will specify which options should be set in the ceph_cluster.yml to enable this.