### PR TITLE
ceph-cluster-setup: support flexible image and registry bootstrap modes

### DIFF
--- a/bootstrap-cluster.sh
+++ b/bootstrap-cluster.sh
@@ -1,46 +1,170 @@
 #!/usr/bin/env bash
-set -x
-{% if local_registry_address is defined and local_registry_address %}
-export IMAGE="{{ local_registry_address }}{{ local_registry_ceph_image }}"
-{% else %}
-export IMAGE="quay.ceph.io/ceph-ci/ceph:main"
-{% endif %}
-export INTERFACE="{% if network_interface_name is defined %}{{ network_interface_name }}{% else %}ens3{% endif %}"
+set -e
 
-#systemctl start firewalld
+echo "===== Ceph Bootstrap Script Starting ====="
+
 export PATH=/root/bin:$PATH
 mkdir -p /root/bin
-{% if ceph_dev_folder is defined %}
-  ln -s  /mnt{{ ceph_dev_folder }}/src/cephadm/cephadm  /root/bin/cephadm
-{% else %}
-  podman run --rm --entrypoint=cat $IMAGE /usr/sbin/cephadm > /root/bin/cephadm
-{% endif %}
-chmod a+rx /root/bin/cephadm
 mkdir -p /etc/ceph
 
+export INTERFACE="${INTERFACE:-ens3}"
+export NETWORK_INTERFACE_TYPE="${NETWORK_INTERFACE_TYPE:-ipv4}"
+
+########################################
+# 1. Setup cephadm
+########################################
+echo "[INFO] Setting up cephadm..."
+echo "[DEBUG] USE_LOCAL_CEPHADM='${USE_LOCAL_CEPHADM:-}' CEPH_DEV_FOLDER='${CEPH_DEV_FOLDER:-}' IMAGE='${IMAGE}' INTERFACE='${INTERFACE}' NETWORK_INTERFACE_TYPE='${NETWORK_INTERFACE_TYPE}'"
+
+if [ "${USE_LOCAL_CEPHADM,,}" = "true" ]; then
+  echo "[INFO] Using local cephadm from dev folder"
+
+  if [ -z "${CEPH_DEV_FOLDER:-}" ]; then
+    echo "[ERROR] CEPH_DEV_FOLDER not set"
+    exit 1
+  fi
+
+  cp -f /mnt/${CEPH_DEV_FOLDER}/src/cephadm/cephadm /root/bin/cephadm
+else
+  echo "[INFO] Extracting cephadm from image: ${IMAGE}"
+
+  if [ -n "${REGISTRY_USERNAME:-}" ] && [ -n "${REGISTRY_PASSWORD:-}" ]; then
+    echo "[INFO] Logging into registry ${REGISTRY_URL}"
+    podman login "${REGISTRY_URL}" -u "${REGISTRY_USERNAME}" -p "${REGISTRY_PASSWORD}"
+  else
+    echo "[INFO] No registry credentials provided; skipping podman login"
+  fi
+
+  CID=$(podman create "${IMAGE}")
+  podman cp ${CID}:/usr/sbin/cephadm /root/bin/cephadm
+  podman rm ${CID}
+fi
+
+chmod a+rx /root/bin/cephadm
+echo "[INFO] cephadm ready: $(which cephadm)"
+
+########################################
+# 2. Prepare registry auth for cephadm
+########################################
+REGISTRY_ARGS=""
+
+if [ -n "${REGISTRY_USERNAME:-}" ] && [ -n "${REGISTRY_PASSWORD:-}" ]; then
+  echo "[INFO] Creating registry auth JSON"
+
+  cat <<EOF > /root/registry-login.json
+{
+  "url": "${REGISTRY_URL}",
+  "username": "${REGISTRY_USERNAME}",
+  "password": "${REGISTRY_PASSWORD}"
+}
+EOF
+
+  REGISTRY_ARGS="--registry-json /root/registry-login.json"
+else
+  echo "[INFO] No registry credentials provided; skipping registry auth JSON"
+fi
+
+########################################
+# 3. Optional IBM license acceptance
+########################################
+LICENSE_ARGS=""
+
+if [[ "${IMAGE}" == cp.icr.io/cp/ibm-ceph/* || "${IMAGE}" == cp.stg.icr.io/cp/ibm-ceph/* ]]; then
+  echo "[INFO] IBM Storage Ceph image detected; enabling automatic license acceptance"
+  LICENSE_ARGS="--automatically-accept-license"
+else
+  echo "[INFO] Non-IBM registry image detected; skipping license auto-accept flag"
+fi
+
+########################################
+# 4. Get MON IP using requested interface
+########################################
 get_mon_ip() {
   local mon_ip
-  mon_ip=$(ip a show $INTERFACE | grep 'inet6 ' | grep -v 'fe80' | awk '{print $2}' | cut -d'/' -f1 | head -n 1)
-  # If no IPv6 found, check for IPv4
-  if [ -z "$mon_ip" ]; then
-    mon_ip=$(ip a show $INTERFACE | grep 'inet ' | awk '{print $2}' | cut -d'/' -f1 | head -n 1)
+
+  if [ "${NETWORK_INTERFACE_TYPE}" = "ipv6" ]; then
+    mon_ip=$(ip a show "${INTERFACE}" | grep 'inet6 ' | grep -v 'fe80' | awk '{print $2}' | cut -d'/' -f1 | head -n 1)
+  else
+    mon_ip=$(ip a show "${INTERFACE}" | grep 'inet ' | awk '{print $2}' | cut -d'/' -f1 | head -n 1)
   fi
-  echo "$mon_ip"
+
+  if [ -z "${mon_ip}" ]; then
+    mon_ip=$(ip a show "${INTERFACE}" | grep 'inet6 ' | grep -v 'fe80' | awk '{print $2}' | cut -d'/' -f1 | head -n 1)
+  fi
+
+  if [ -z "${mon_ip}" ]; then
+    mon_ip=$(ip a show "${INTERFACE}" | grep 'inet ' | awk '{print $2}' | cut -d'/' -f1 | head -n 1)
+  fi
+
+  echo "${mon_ip}"
 }
 
 mon_ip=$(get_mon_ip)
-{% if ceph_dev_folder is defined %}
-  python3 /root/bin/cephadm  --image $IMAGE bootstrap --mon-ip $mon_ip --initial-dashboard-password {{ admin_password }} --skip-monitoring-stack --allow-fqdn-hostname --dashboard-password-noupdate --shared_ceph_folder /mnt/{{ ceph_dev_folder }} 
-{% else %}
-  python3 /root/bin/cephadm  --image $IMAGE bootstrap --mon-ip $mon_ip --initial-dashboard-password {{ admin_password }} --allow-fqdn-hostname --dashboard-password-noupdate
-{% endif %}
-fsid=$(cat /etc/ceph/ceph.conf | grep fsid | awk '{ print $3}')
-{% for number in range(1, nodes) %}
-  ssh-copy-id -f -i /etc/ceph/ceph.pub  -o StrictHostKeyChecking=no root@{{ node_prefix_1 }}-node-{{ '%d' % number }}
-  {% if network_interface_type is defined and network_interface_type == 'ipv6' %}
-  python3 /root/bin/cephadm shell --fsid $fsid -c /etc/ceph/ceph.conf -k /etc/ceph/ceph.client.admin.keyring ceph orch host add {{ node_prefix_1 }}-node-{{ '%d' % number }} {{ ipv6_prefix_1 }}::{{ '%x' % (node_ip_offset + number) }}
-  {% else %}
-  python3 /root/bin/cephadm shell --fsid $fsid -c /etc/ceph/ceph.conf -k /etc/ceph/ceph.client.admin.keyring ceph orch host add {{ node_prefix_1 }}-node-{{ '%d' % number }} {{  ip_prefix_1 }}.10{{ '%d' % number }}
-  {% endif %}
-{% endfor %}
-python3 /root/bin/cephadm shell --fsid $fsid -c /etc/ceph/ceph.conf -k /etc/ceph/ceph.client.admin.keyring ceph orch apply osd --all-available-devices
+
+if [ -z "${mon_ip}" ]; then
+  echo "[ERROR] Could not detect MON IP on interface ${INTERFACE}"
+  ip a
+  exit 1
+fi
+
+echo "[INFO] MON IP detected: ${mon_ip}"
+
+########################################
+# 5. Bootstrap cluster
+########################################
+echo "[INFO] Running cephadm bootstrap"
+
+SHARED_CEPH_ARGS=""
+if [ -n "${CEPH_DEV_FOLDER:-}" ]; then
+  SHARED_CEPH_ARGS="--shared_ceph_folder /mnt/${CEPH_DEV_FOLDER}"
+fi
+
+python3 /root/bin/cephadm --image "${IMAGE}" bootstrap \
+  --mon-ip "${mon_ip}" \
+  --initial-dashboard-password "${ADMIN_PASSWORD}" \
+  ${REGISTRY_ARGS} \
+  ${LICENSE_ARGS} \
+  ${SHARED_CEPH_ARGS} \
+  --allow-fqdn-hostname \
+  --dashboard-password-noupdate \
+  --skip-monitoring-stack \
+  --no-cleanup-on-failure
+
+########################################
+# 6. Add hosts
+########################################
+echo "[INFO] Adding hosts to cluster"
+
+fsid=$(awk '/fsid/ {print $3}' /etc/ceph/ceph.conf)
+
+for number in $(seq 1 $((NODES-1))); do
+  node_name="${NODE_PREFIX}-node-${number}"
+
+  if [ "${NETWORK_INTERFACE_TYPE}" = "ipv6" ]; then
+    node_ip="${IPV6_PREFIX}::$(printf '%x' $((NODE_IP_OFFSET + number)))"
+  else
+    node_ip="${IP_PREFIX}.10${number}"
+  fi
+
+  echo "[INFO] Adding host ${node_name} (${node_ip})"
+
+  ssh-copy-id -f -i /etc/ceph/ceph.pub \
+    -o StrictHostKeyChecking=no root@${node_name}
+
+  python3 /root/bin/cephadm shell --fsid "${fsid}" \
+    -c /etc/ceph/ceph.conf \
+    -k /etc/ceph/ceph.client.admin.keyring \
+    ceph orch host add "${node_name}" "${node_ip}"
+done
+
+########################################
+# 7. Apply OSDs
+########################################
+echo "[INFO] Applying OSDs on all available devices"
+
+python3 /root/bin/cephadm shell --fsid "${fsid}" \
+  -c /etc/ceph/ceph.conf \
+  -k /etc/ceph/ceph.client.admin.keyring \
+  ceph orch apply osd --all-available-devices
+
+echo "===== Ceph Bootstrap Completed Successfully ====="

--- a/ceph_cluster.yml
+++ b/ceph_cluster.yml
@@ -5,41 +5,42 @@ parameters:
  node_prefix_1: ceph
  network_1: ceph-orch
  ip_prefix_1: 192.168.100
- ipv6_prefix_1: ''  # Example of a real IPv6 prefix: '2620:52:0:1304'
- local_registry_address: "" # Example: "192.168.100.254:5000"
- local_registry_ceph_image: '' # Example: "/ceph/ceph:main"
+ ipv6_prefix_1: ''
  netmask: 255.255.255.0
  numcpus: 1
  memory: 6144
- image: fedora43
+ vm_image: fedora43
  notify: false
  admin_password: password
+
+ # Ceph container image. Can be upstream, custom quay, DS prod, or DS staging.
+ image: quay.ceph.io/ceph-ci/ceph:main
+
+ # Optional private registry auth.
+ registry_url: ""
+ registry_username: ""
+ registry_password: ""
+
+ # If true, cephadm is copied from ceph_dev_folder.
+ # If false, cephadm is extracted from the selected image.
+ use_local_cephadm: false
+
+ # Network settings
  network_interface_name: ens3
  network_interface_type: ipv4
- bootstrap_server_as_ntp_source: false  # if set as true, the first node will act as an ntp server for the rest of the nodes
- container_cfg:
-   engine:
-     env:   # when you are behind vpn or similar env and require to pass through a proxy ,put your proxy configyuration
-       #- HTTP_PROXY: "http://example.net:8080"
-       #- HTTPS_PROXY: "http://example.net:8080"
-       #- http_proxy: "http://example.net:8080"
-       #- https_proxy: "http://example.net:8080"
-       - NO_PROXY: "localhost,127.0.0.1,{{ ip_prefix_1 }}.0/24"
+
  disks:
- - size: 100               # Disk 1 (OS)
- - size: 10                # Disk 2 (Ceph Data)
+ - 100
+ - 10
 
 {% for number in range(0, nodes) %}
 {{ node_prefix_1 }}-node-{{ '%d' % number }}:
- image: {{ image }}
+ image: {{ vm_image }}
  numcpus: {{ numcpus }}
  memory: {{ memory }}
  reserveip: true
  reservedns: true
  sharedkey: true
- user: fedora
- keys:
-  - ~/.ssh/id_ed25519.pub
  nets:
   - name: {{ network_1 }}
     ip: {{ ip_prefix_1 }}.{{ node_ip_offset + number }}
@@ -56,7 +57,7 @@ parameters:
  sharedfolders: [{{ ceph_dev_folder }}]
  {% endif %}
  files:
-  - bootstrap-cluster.sh
+   - bootstrap-cluster.sh
  cmds:
 {% if network_interface_type is defined and network_interface_type == 'ipv6' %}
  - connection_name=$(nmcli -g NAME,DEVICE con show | grep "{{ network_interface_name }}" | cut -d ':' -f1)
@@ -67,39 +68,13 @@ parameters:
  - echo '{{ ipv6_prefix_1 }}::{{ '%x' % (node_ip_offset + i) }} {{ node_prefix_1 }}-node-{{ i }}' >> /etc/hosts
 {% endfor %}
 {% endif %}
- - dnf -y install python3 chrony lvm2 podman nano strace firewalld tcpdump net-tools vim
+ - dnf -y install python3 chrony lvm2 podman nano strace firewalld tcpdump curl net-tools vim
+ - systemctl enable --now chronyd
+ - systemctl enable --now firewalld || true
  - sed -i "s/SELINUX=enforcing/SELINUX=permissive/" /etc/selinux/config
- - setenforce 0
- - mkdir -p /etc/containers
- {% if container_cfg is defined %}
- - echo "[engine]" > /etc/containers/containers.conf
- - echo "env = [" >> /etc/containers/containers.conf
- {% for env_entry in container_cfg.engine.env %}
- {% set key_val = env_entry.items() | list | first %}
- - echo "    \"{{ key_val[0] }}={{ key_val[1] }}\"{{ ',' if not loop.last else '' }}" >> /etc/containers/containers.conf
- {% endfor %}
- - echo "]" >> /etc/containers/containers.conf
- {% endif %}
- {% if local_registry_address is defined and local_registry_address %}
- - echo "[[registry]]" > /etc/containers/registries.conf
- - echo "location = \"{{ local_registry_address }}\"" >> /etc/containers/registries.conf
- - echo "insecure = true" >> /etc/containers/registries.conf
- {% endif %}
- {% if bootstrap_server_as_ntp_source is defined %}
- {% if number == 0 %}
- - sed -i -r '/^(server|pool) /d' /etc/chrony.conf
- - echo "local stratum 10" >> /etc/chrony.conf
- - echo "allow {{ ip_prefix_1 }}.0/24" >> /etc/chrony.conf
- - systemctl enable chronyd
- - systemctl restart chronyd
- {% else %}
- - sed -i -r '/^(server|pool) /d' /etc/chrony.conf
- - echo "server {{ ip_prefix_1 }}.{{ node_ip_offset }} iburst" >> /etc/chrony.conf
- - systemctl enable chronyd
- - systemctl restart chronyd
- {% endif %}
- {% endif %}
- {% if number == 0 %}
- - bash /root/bootstrap-cluster.sh
- {% endif %}
+ - setenforce 0 || true
+ - if [ -n "{{ registry_username }}" ] && [ -n "{{ registry_password }}" ]; then podman login "{{ registry_url }}" -u "{{ registry_username }}" -p "{{ registry_password }}"; fi
+{% if number == 0 %}
+ - IMAGE="{{ image }}" ADMIN_PASSWORD="{{ admin_password }}" USE_LOCAL_CEPHADM="{{ use_local_cephadm | lower }}" NODES="{{ nodes }}" NODE_PREFIX="{{ node_prefix_1 }}" NODE_IP_OFFSET="{{ node_ip_offset }}" IP_PREFIX="{{ ip_prefix_1 }}" IPV6_PREFIX="{{ ipv6_prefix_1 }}" INTERFACE="{{ network_interface_name }}" NETWORK_INTERFACE_TYPE="{{ network_interface_type }}" REGISTRY_URL="{{ registry_url }}" REGISTRY_USERNAME="{{ registry_username }}" REGISTRY_PASSWORD="{{ registry_password }}"{% if ceph_dev_folder is defined %} CEPH_DEV_FOLDER="{{ ceph_dev_folder }}"{% endif %} bash /root/bootstrap-cluster.sh
+{% endif %}
 {% endfor %}


### PR DESCRIPTION
ceph-cluster-setup: support flexible image and registry bootstrap modes

The cluster image is now controlled through a generic `image` parameter instead of a upstream or downstream-specific image field.
This allows the same template to bootstrap from upstream public images, custom quay.io images, downstream production images, or downstream staging images.

    Add support for two cephadm bootstrap modes:
    - image-based mode, where cephadm is extracted from the selected container image
    - local development mode, where cephadm is copied from the mounted i'ceph_dev_folder'

    Supported workflows include:

    - default upstream cluster using `quay.ceph.io/ceph-ci/ceph:main`
    - public custom quay image with local cephadm
    - downstream production image with registry login
    - downstream staging image with registry login
    - downstream image with local cephadm for development/testing
    - When we pass:

    -P registry_url='cp.icr.io' \
    -P registry_username='cp' \
    -P registry_password='TOKEN'

    or:

    -P registry_url='cp.stg.icr.io' \
    -P registry_username='cp' \
    -P registry_password='TOKEN'

    the YAML runs podman login on each node during provisioning, so we no longer need to manually log in to every node.

    The bootstrap script also creates a registry-login.json and passes it to
    cephadm bootstrap via --registry-json, so cephadm has the registry credentials for its own image pulls as well.

    1. Upstream cluster with local cephadm

    Uses default upstream image, but bootstrap uses local cephadm:

    kcli create plan -f ./ceph-cluster-auto-merged.yaml \
      -P use_local_cephadm=true \
      -P ceph_dev_folder=/home/kushaldeb/github/ceph \
      ceph

    2. Public custom quay image with local cephadm

    Uses custom image for daemons, but local cephadm for bootstrap:

    kcli create plan -f ./ceph_cluster.yaml \
      -P use_local_cephadm=true \
      -P ceph_dev_folder=/home/kushaldeb/github/ceph \
      -P image='quay.io/kdeb/ceph:d3n' \
      ceph

    3. Downstream production image

    Uses cp.icr.io and registry credentials, this extracts cephadm binary
    from the image automatically:

    kcli create plan -f ./ceph_cluster.yaml \
      -P image='cp.icr.io/cp/ibm-ceph/ceph-8-rhel9-xxxx' \
      -P registry_url='cp.icr.io' \
      -P registry_username='cp' \
      -P registry_password='TOKEN' \
      ceph

    4. Downstream staging image

    Uses cp.stg.icr.io and registry credentials:

    kcli create plan -f ./ceph-cluster-auto-merged.yaml \
      -P image='cp.stg.icr.io/cp/ibm-ceph/ceph-9-rhel9-xxxx' \
      -P registry_url='cp.stg.icr.io' \
      -P registry_username='cp' \
      -P registry_password='TOKEN' \
      ceph

    5. Downstream image with local cephadm

    Uses DS image, registry auth, and local cephadm:

    kcli create plan -f ./ceph_cluster.yaml \
      -P use_local_cephadm=true \
      -P ceph_dev_folder=/home/kushaldeb/Downstream-Ceph/ceph \
      -P image='cp.icr.io/cp/ibm-ceph/ceph-8-rhel9-xxxx' \
      -P registry_url='cp.icr.io' \
      -P registry_username='cp' \
      -P registry_password='TOKEN' \
      ceph

    'use_local_cephadm' controls where the bootstrap cephadm binary comes from.

    use_local_cephadm=false: extract /usr/sbin/cephadm from the selected image
    and use that to bootstrap.

    use_local_cephadm=true: copy cephadm from the mounted local source tree
    at ceph_dev_folder/src/cephadm/cephadm and use that to bootstrap.